### PR TITLE
Fix package imports for API

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse
-from inicializar_app import inicializar_app
-from painel import render_painel
+from .inicializar_app import inicializar_app
+from .painel import render_painel
 
 app = FastAPI()
 
@@ -22,7 +22,7 @@ async def executar_tarefa(request: Request):
     body = await request.json()
     tarefa = body.get("tarefa")
     if tarefa == "distribuir_emails":
-        from distribuidor_emails import distribuir_emails
+        from .distribuidor_emails import distribuir_emails
         distribuir_emails()
         return {"status": "ok", "executado": tarefa}
     return {"status": "erro", "mensagem": "Tarefa não reconhecida"}

--- a/api/inicializar_app.py
+++ b/api/inicializar_app.py
@@ -3,7 +3,7 @@ def inicializar_app():
 
     # Exemplo de chamadas reais
     try:
-        from distribuidor_emails import distribuir_emails
+        from .distribuidor_emails import distribuir_emails
         distribuir_emails()
     except Exception as e:
         print(f"Erro ao distribuir e-mails: {e}")


### PR DESCRIPTION
## Summary
- fix imports in `api` module to use package-relative paths
- adjust email distributor reference

## Testing
- `python -m api.app`
- `python - <<'EOF'
import api.app
print('done')
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68589c1f6f388326878448adbf5b41f8