### PR TITLE
Remove conflict markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-<<<<<<< HEAD
-# Estrutura para deploy no Codespaces
-=======
 # 🚀 Propulsor Intelligence
 
 ## Estrutura para Deploy no Codespaces
@@ -19,4 +16,4 @@ Este repositório contém a infraestrutura modular do **Propulsor**, já integra
 ### ▶️ Execução direta
 ```bash
 start run_propulsor.bat
->>>>>>> c95de31 (Atualização completa do Codespace para o repositório remoto)
+```

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,2 @@
-<<<<<<< HEAD
 #!/bin/bash
 streamlit run app.py --server.port=$PORT --server.address=0.0.0.0
-=======
-#!/bin/bash
-streamlit run app.py --server.port=$PORT --server.address=0.0.0.0
->>>>>>> 0e85ea7 (Força inclusão do start.sh no repo)


### PR DESCRIPTION
## Summary
- clean up merge markers in README
- keep one startup command in `start.sh`

## Testing
- `pytest -q --ignore=teste_push_final.txt`

------
https://chatgpt.com/codex/tasks/task_e_68589f166c5c83268ee95fda92f1aebe

## Resumo por Sourcery

Remover marcadores de conflito de merge remanescentes e comandos de inicialização duplicados

Documentação:
- Remover marcadores de conflito do Git de README.md e restaurar blocos de código adequados

Tarefas:
- Simplificar start.sh ao remover a duplicação do shebang e do comando de inicialização do Streamlit

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove leftover merge conflict markers and duplicate startup commands

Documentation:
- Remove Git conflict markers from README.md and restore proper code blocks

Chores:
- Simplify start.sh by deduplicating shebang and Streamlit startup command

</details>