### PR TITLE
Add dynamic CRUD backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@
 !services/**
 !scripts/
 !scripts/**
+!propulsor-backend/
+!propulsor-backend/**
+!database/
+!database/**
 !utils.py
 !importador_espader.bat
 !consolidar_contencioso.bat
@@ -26,6 +30,8 @@
 !painel/**
 !codespaces/
 !codespaces/**
+!docs/
+!docs/**
 
 # Ignorar arquivos de ambiente
 .env                # <-- .env NUNCA vai pro repo!

--- a/README.md
+++ b/README.md
@@ -76,3 +76,21 @@ python -m scripts.duplicidades nome_da_tabela coluna_chave
 ```
 
 O script exibirá os valores repetidos e suas ocorrências para cada arquivo `.db` encontrado.
+
+### 📚 Endpoints da API
+Consulte `docs/endpoints.md` para detalhes dos endpoints disponíveis e exemplo de integração.
+
+### ⚡ CRUD Rápido
+Execute `python propulsor-backend/app.py` para subir um backend Flask com todos os bancos da pasta `database/`.
+
+Endpoints disponíveis por tabela:
+
+```
+GET    /api/<tabela>
+GET    /api/<tabela>/<id>
+POST   /api/<tabela>
+PUT    /api/<tabela>/<id>
+DELETE /api/<tabela>/<id>
+```
+
+Os arquivos HTML em `propulsor-backend/static/` demonstram como consumir a API via `fetch`.

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -1,0 +1,47 @@
+# Checklist de Endpoints por Módulo
+
+Este documento resume os principais endpoints REST disponíveis no projeto **Propulsor**. Os bancos SQLite devem estar na pasta `database/` e cada tabela recebe automaticamente um endpoint CRUD no formato `/api/<tabela>`.
+
+## Exemplos de Uso
+- `GET /api/pessoas` — lista todos os registros da tabela `pessoas`.
+- `GET /api/contratos/5` — busca o contrato com ID 5.
+- `POST /api/instituicoes` — cria uma instituição.
+- `PUT /api/contencioso/10` — atualiza o registro 10.
+- `DELETE /api/procuracoes/3` — remove a procuração de ID 3.
+
+Os endpoints são gerados de forma dinâmica para cada banco e tabela encontrada em `database/`.
+
+## Exemplo de Integração
+```html
+<!-- Lista pessoas em uma tabela -->
+<table id="pessoas-tabela"></table>
+<script>
+fetch('/api/pessoas/pessoas')
+  .then(res => res.json())
+  .then(data => {
+    const tabela = document.getElementById('pessoas-tabela');
+    tabela.innerHTML = `
+      <tr>
+        <th>ID</th><th>Nome</th><th>CPF/CNPJ</th>
+      </tr>
+      ${data.map(p => `
+        <tr>
+          <td>${p.id}</td>
+          <td>${p.nome}</td>
+          <td>${p.cpf_cnpj}</td>
+        </tr>
+      `).join('')}
+    `;
+  });
+</script>
+```
+
+---
+
+### Orientações para novos módulos
+- Adicione o `.db` correspondente em `database/`.
+- O endpoint será criado automaticamente no formato `/api/<tabela>`.
+- O frontend deve consumir os dados via `fetch` a partir da pasta `static/`.
+
+Estas diretrizes servem de referência rápida para onboarding de desenvolvedores e para a manutenção dos padrões do Propulsor.
+

--- a/propulsor-backend/app.py
+++ b/propulsor-backend/app.py
@@ -1,0 +1,80 @@
+from flask import Flask, jsonify, request
+import sqlite3
+import os
+
+app = Flask(__name__)
+DB_FOLDER = os.path.join(os.path.dirname(__file__), 'database')
+
+
+def listar_tabelas(dbfile):
+    conn = sqlite3.connect(dbfile)
+    cur = conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    tabelas = [r[0] for r in cur.fetchall()]
+    conn.close()
+    return tabelas
+
+
+def query_rows(dbpath, query, params=()):
+    conn = sqlite3.connect(dbpath)
+    cur = conn.execute(query, params)
+    rows = cur.fetchall()
+    columns = [c[0] for c in cur.description] if cur.description else []
+    conn.commit()
+    conn.close()
+    return [dict(zip(columns, row)) for row in rows]
+
+
+for dbfile in os.listdir(DB_FOLDER):
+    if not dbfile.endswith('.db'):
+        continue
+    dbpath = os.path.join(DB_FOLDER, dbfile)
+    for tab in listar_tabelas(dbpath):
+        route = f'/api/{tab}'
+
+        def list_all(tab=tab, dbpath=dbpath):
+            return jsonify(query_rows(dbpath, f'SELECT * FROM {tab}'))
+        app.add_url_rule(route, f'get_{tab}', list_all, methods=['GET'])
+
+        def get_one(idx, tab=tab, dbpath=dbpath):
+            rows = query_rows(dbpath, f'SELECT * FROM {tab} WHERE id=?', (idx,))
+            return (jsonify(rows[0]) if rows else ('', 404))
+        app.add_url_rule(f'{route}/<int:idx>', f'get_{tab}_id', get_one, methods=['GET'])
+
+        def create(tab=tab, dbpath=dbpath):
+            data = request.json or {}
+            keys = ','.join(data.keys())
+            placeholders = ','.join(['?'] * len(data))
+            vals = tuple(data.values())
+            conn = sqlite3.connect(dbpath)
+            cur = conn.execute(
+                f'INSERT INTO {tab} ({keys}) VALUES ({placeholders})', vals
+            )
+            conn.commit()
+            conn.close()
+            return jsonify({'id': cur.lastrowid})
+        app.add_url_rule(route, f'post_{tab}', create, methods=['POST'])
+
+        def update(idx, tab=tab, dbpath=dbpath):
+            data = request.json or {}
+            sets = ','.join(f"{k}=?" for k in data)
+            vals = tuple(data.values()) + (idx,)
+            conn = sqlite3.connect(dbpath)
+            conn.execute(
+                f'UPDATE {tab} SET {sets} WHERE id=?', vals
+            )
+            conn.commit()
+            conn.close()
+            return jsonify({'ok': True})
+        app.add_url_rule(f'{route}/<int:idx>', f'put_{tab}', update, methods=['PUT'])
+
+        def delete(idx, tab=tab, dbpath=dbpath):
+            conn = sqlite3.connect(dbpath)
+            conn.execute(f'DELETE FROM {tab} WHERE id=?', (idx,))
+            conn.commit()
+            conn.close()
+            return jsonify({'ok': True})
+        app.add_url_rule(f'{route}/<int:idx>', f'del_{tab}', delete, methods=['DELETE'])
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/propulsor-backend/static/consorcios.html
+++ b/propulsor-backend/static/consorcios.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8">
+  <title>Consorcios</title>
+</head>
+<body data-module="consorcios">
+<h1>Consorcios</h1>
+<table id="data-table"></table>
+<script src="module.js"></script>
+<script>loadModule('consorcios');</script>
+</body>
+</html>

--- a/propulsor-backend/static/contencioso.html
+++ b/propulsor-backend/static/contencioso.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8">
+  <title>Contencioso</title>
+</head>
+<body data-module="contencioso">
+<h1>Contencioso</h1>
+<table id="data-table"></table>
+<script src="module.js"></script>
+<script>loadModule('contencioso');</script>
+</body>
+</html>

--- a/propulsor-backend/static/contratos.html
+++ b/propulsor-backend/static/contratos.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8">
+  <title>Contratos</title>
+</head>
+<body data-module="contratos">
+<h1>Contratos</h1>
+<table id="data-table"></table>
+<script src="module.js"></script>
+<script>loadModule('contratos');</script>
+</body>
+</html>

--- a/propulsor-backend/static/depositos.html
+++ b/propulsor-backend/static/depositos.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8">
+  <title>Depositos</title>
+</head>
+<body data-module="depositos">
+<h1>Depositos</h1>
+<table id="data-table"></table>
+<script src="module.js"></script>
+<script>loadModule('depositos');</script>
+</body>
+</html>

--- a/propulsor-backend/static/instituicoes.html
+++ b/propulsor-backend/static/instituicoes.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8">
+  <title>Instituicoes</title>
+</head>
+<body data-module="instituicoes">
+<h1>Instituicoes</h1>
+<table id="data-table"></table>
+<script src="module.js"></script>
+<script>loadModule('instituicoes');</script>
+</body>
+</html>

--- a/propulsor-backend/static/module.js
+++ b/propulsor-backend/static/module.js
@@ -1,0 +1,12 @@
+async function loadModule(moduleName) {
+  const res = await fetch(`/api/${moduleName}`);
+  const data = await res.json();
+  const table = document.getElementById('data-table');
+  if (!Array.isArray(data) || data.length === 0) {
+    table.innerHTML = '<tr><td>Sem dados</td></tr>';
+    return;
+  }
+  const headers = Object.keys(data[0]);
+  table.innerHTML = '<tr>' + headers.map(h => `<th>${h}</th>`).join('') + '</tr>' +
+    data.map(row => '<tr>' + headers.map(h => `<td>${row[h]}</td>`).join('') + '</tr>').join('');
+}

--- a/propulsor-backend/static/pessoas.html
+++ b/propulsor-backend/static/pessoas.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8">
+  <title>Pessoas</title>
+</head>
+<body data-module="pessoas">
+<h1>Pessoas</h1>
+<table id="data-table"></table>
+<script src="module.js"></script>
+<script>loadModule('pessoas');</script>
+</body>
+</html>

--- a/propulsor-backend/static/procuracoes.html
+++ b/propulsor-backend/static/procuracoes.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8">
+  <title>Procuracoes</title>
+</head>
+<body data-module="procuracoes">
+<h1>Procuracoes</h1>
+<table id="data-table"></table>
+<script src="module.js"></script>
+<script>loadModule('procuracoes');</script>
+</body>
+</html>

--- a/propulsor-backend/static/requisicoes.html
+++ b/propulsor-backend/static/requisicoes.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8">
+  <title>Requisicoes</title>
+</head>
+<body data-module="requisicoes">
+<h1>Requisicoes</h1>
+<table id="data-table"></table>
+<script src="module.js"></script>
+<script>loadModule('requisicoes');</script>
+</body>
+</html>

--- a/propulsor-backend/static/usuarios.html
+++ b/propulsor-backend/static/usuarios.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8">
+  <title>Usuarios</title>
+</head>
+<body data-module="usuarios">
+<h1>Usuarios</h1>
+<table id="data-table"></table>
+<script src="module.js"></script>
+<script>loadModule('usuarios');</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- allow backend and database directories in `.gitignore`
- implement Flask app with automatic CRUD for all SQLite tables
- document usage in README and update endpoints guide
- add simple HTML frontends for each module with generic table render

## Testing
- `python -m py_compile propulsor-backend/app.py`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6861f300f1988326b8880a69005e2c17