### PR TITLE
Add SQL import batch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 !importador_espader.bat
 !consolidar_contencioso.bat
 !criar_propulsor_db.bat
+!importar_banco_fusione.bat
 !netlify.toml
 !data/
 !data/**

--- a/importar_banco_fusione.bat
+++ b/importar_banco_fusione.bat
@@ -1,0 +1,18 @@
+@echo off
+REM Importa todos os arquivos SQL limpos para o MariaDB do XAMPP
+REM Ajuste o caminho do MySQL se necessário
+set MYSQL_PATH=C:\xampp\mysql\bin\mysql.exe
+set DB_NAME=fusione
+set SQL_FOLDER="C:\xampp\fusione\Uploaded Files_ static"
+
+cd /d %SQL_FOLDER%
+
+python "%~dp0scripts\corrigir_sql.py"
+
+for %%F in (limpo_*.sql) do (
+    echo Importando %%F ...
+    "%MYSQL_PATH%" -u root %DB_NAME% < "%%F"
+)
+
+echo Importacao concluida.
+pause

--- a/scripts/corrigir_sql.py
+++ b/scripts/corrigir_sql.py
@@ -1,0 +1,49 @@
+import os
+import re
+
+SQL_DIR = r"C:\\xampp\\fusione\\Uploaded Files_ static"
+
+INVALID_PATTERNS = [
+    r"PRAGMA", r"TRANSACTION", r"BEGIN", r"COMMIT"
+]
+
+REPLACEMENTS = {
+    '├º': 'ç', '├ú': 'ã', '├¡': 'á', '├â': 'â',
+    '├Ã©': 'é', 'Ã§': 'ç', 'Ã£': 'ã', 'Ã³': 'ó',
+    'Ã¡': 'á', 'Ãª': 'ê', 'Ã©': 'é', 'Ãº': 'ú',
+    'Ã­': 'í', 'Ã¢': 'â', 'Ã ': 'à'
+}
+
+
+def clean_line(line: str) -> str:
+    for wrong, right in REPLACEMENTS.items():
+        if wrong in line:
+            line = line.replace(wrong, right)
+    return line
+
+
+def process_file(path: str, output_path: str) -> None:
+    with open(path, 'r', encoding='utf-8', errors='ignore') as f:
+        lines = f.readlines()
+
+    cleaned = []
+    for line in lines:
+        if any(re.search(p, line, re.IGNORECASE) for p in INVALID_PATTERNS):
+            continue
+        cleaned.append(clean_line(line))
+
+    with open(output_path, 'w', encoding='utf-8') as f:
+        f.writelines(cleaned)
+
+
+def main() -> None:
+    for fname in os.listdir(SQL_DIR):
+        if fname.lower().endswith('.sql') and not fname.startswith('limpo_'):
+            src = os.path.join(SQL_DIR, fname)
+            dst = os.path.join(SQL_DIR, f'limpo_{fname}')
+            process_file(src, dst)
+            print(f'Gerado {dst}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add batch script `importar_banco_fusione.bat` to clean and load SQL dumps into MariaDB
- provide helper `scripts/corrigir_sql.py` for basic encoding and syntax fix
- allow new batch script in `.gitignore`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686c556324fc8326a10c5e2afe69e8d6