### PR TITLE
Add Fusione docs and import utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,6 @@ python -m scripts.duplicidades nome_da_tabela coluna_chave
 ```
 
 O script exibirá os valores repetidos e suas ocorrências para cada arquivo `.db` encontrado.
+
+### 📚 Documentação Fusione
+Consulte `data/docs/README_FUSIONE_COMPLETO.md` para o guia de instalação e importância de dados.

--- a/data/docs/FUSIONE_CHECKLIST.md
+++ b/data/docs/FUSIONE_CHECKLIST.md
@@ -1,0 +1,19 @@
+# Checklist de Módulos do Fusione
+
+| Módulo            | Backend | Frontend | Status |
+|--------------------|---------|----------|-------|
+| Pessoas            | Python (Flask) | React/HTML | OK |
+| Consórcios        | Python (Flask) | Streamlit | OK |
+| Contencioso        | Python (Flask) | Streamlit | OK |
+| Contratos          | Python (Flask) | - | Em análise |
+| Procuracões       | -       | -        | Pendente |
+| Requisições       | -       | -        | Pendente |
+| Societário        | -       | -        | Pendente |
+| Finanças Pessoais | -       | -        | Pendente |
+| Ciência de Dados  | -       | Power BI | Pendente |
+| Dashboards         | FastAPI  | React    | OK |
+
+Legenda:
+- **OK**: funcional no repositório
+- **Em análise**: necessita revisão
+- **Pendente**: aguarda implementação

--- a/data/docs/README_FUSIONE_COMPLETO.md
+++ b/data/docs/README_FUSIONE_COMPLETO.md
@@ -1,0 +1,43 @@
+# Manual Completo do Fusione
+
+Este guia resume os passos de instalação e uso do **Fusione**, integrando o padrão de projetos do Propulsor.
+
+## Requisitos
+- Windows 10 ou superior com XAMPP instalado
+- Python 3.10+
+- MySQL (fornecido pelo XAMPP)
+
+Crie um arquivo `.env` baseado em `.env.example` contendo as credenciais do banco:
+
+```ini
+MYSQL_HOST=localhost
+MYSQL_USER=root
+MYSQL_PASSWORD=
+MYSQL_DB=fusione
+SQL_DIR=C:\xampp\fusione\sql
+```
+
+## Instalação
+1. Clone o repositório `propulsor-intelligence` e mantenha a estrutura padrão de pastas.
+2. Execute `importar_banco_fusione.bat` ou o script `scripts/importar_fusione.py` para carregar os arquivos `.sql` da pasta definida em `SQL_DIR`.
+3. Inicie o Apache e o MySQL pelo XAMPP. Acesse `http://localhost/fusione/` para verificar.
+
+### Importação via Python
+Opcionalmente, rode:
+
+```bash
+python scripts/importar_fusione.py
+```
+
+O script processa todos os arquivos `.sql` presentes em `SQL_DIR` e executa no banco configurado no `.env`.
+
+## Hospedagem com Domínio
+Após o ambiente local estar funcionando:
+1. Aponte o DNS do seu domínio para o IP público do computador.
+2. Configure o redirecionamento de portas 80/443 no roteador para a máquina que executa o XAMPP.
+3. Libere as mesmas portas no firewall do Windows.
+
+Com isso, o Fusione poderá ser acessado em `http://seu-dominio.com.br`.
+
+## Suporte
+Dúvidas ou falhas podem ser reportadas diretamente ao time Propulsor.

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ git+https://github.com/openai/whisper.git
 Flask
 flask-cors
 python-dotenv
+mysql-connector-python

--- a/scripts/importar_fusione.py
+++ b/scripts/importar_fusione.py
@@ -1,0 +1,45 @@
+"""Importa arquivos SQL do Fusione no MySQL definido no .env."""
+from __future__ import annotations
+
+import os
+import mysql.connector
+from pathlib import Path
+from dotenv import load_dotenv
+
+load_dotenv()
+
+SQL_DIR = Path(os.getenv("SQL_DIR", "C:/xampp/fusione/sql"))
+DB_CONFIG = {
+    "host": os.getenv("MYSQL_HOST", "localhost"),
+    "user": os.getenv("MYSQL_USER", "root"),
+    "password": os.getenv("MYSQL_PASSWORD", ""),
+    "database": os.getenv("MYSQL_DB", "fusione"),
+}
+
+
+def run_sql_file(cursor: mysql.connector.cursor.MySQLCursor, path: Path) -> None:
+    with path.open("r", encoding="utf-8", errors="ignore") as file:
+        sql_statements = file.read()
+    for _ in cursor.execute(sql_statements, multi=True):
+        pass
+
+
+def main() -> None:
+    files = sorted(SQL_DIR.glob("*.sql"))
+    if not files:
+        print(f"Nenhum arquivo .sql encontrado em {SQL_DIR}")
+        return
+
+    conn = mysql.connector.connect(**DB_CONFIG)
+    cursor = conn.cursor()
+    for sql_file in files:
+        print(f"Importando {sql_file.name}...")
+        run_sql_file(cursor, sql_file)
+        conn.commit()
+    cursor.close()
+    conn.close()
+    print("Importação concluída.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add detailed Fusione manual
- include module checklist
- provide `importar_fusione.py` for loading SQL files
- mention docs in root README
- add MySQL connector to requirements

## Testing
- `python -m py_compile scripts/importar_fusione.py`

------
https://chatgpt.com/codex/tasks/task_e_687e031f3e2083269d713f0db1451776